### PR TITLE
Fix to store the full E-Mail Address in MySQL

### DIFF
--- a/js/dialogs/FetchmailAccountDialogDetailsPanel.js
+++ b/js/dialogs/FetchmailAccountDialogDetailsPanel.js
@@ -49,7 +49,7 @@ Zarafa.plugins.fetchmail.dialogs.FetchmailAccountDialogDetailsPanel = Ext.extend
                 hideLabel: true,
                 hidden : true,
                 readOnly: true,
-                value : container.getUser().getEmailAddress()
+                value : container.getUser().getSMTPAddress()
             }, {
             	xtype:'textfield',
                 fieldLabel : dgettext('plugin_fetchmail', 'Mail Server'),


### PR DESCRIPTION
Fix to store the full E-Mail Address in MySQL to deliver the mails from fetchmail not just the prefix.
If only the prefix is stored, fetchmal isn't able to deliver the fetched mail to the correct kopano account. #7 